### PR TITLE
Buildability/runnability fixes.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM litaio/ruby
 
 ENV DEBIAN_FRONTEND noninteractive
+ENV RUBY_HARDCODED_IN_STRINGER 2.0.0
 
+## First, our dependencies
 RUN apt-get -y update
 RUN apt-get -y install git
 RUN apt-get -y install libxml2-dev libxslt-dev
@@ -12,16 +14,20 @@ RUN gem install bundler --no-ri --no-rdoc
 RUN gem install foreman --no-ri --no-rdoc
 RUN gem install clockwork -v 1.0.0 --no-ri --no-rdoc
 
+## Grab Stringer
 RUN git clone git://github.com/swanson/stringer.git /stringer
 
+## Stringer's required env variables
 ENV RACK_ENV "production"
 ENV STRINGER_DATABASE "stringerdb"
 
 WORKDIR /stringer
-
-RUN sed -i 's/^ruby "2.0.0"/ruby "2.1.2"/' Gemfile
+## Stringer hardcodes ruby 2.0.0 into it's config file, and
+## also hardocded a development/debug console to run.
+RUN sed -i 's/^ruby "${RUBY_HARDCODED_IN_STRINGER}"/ruby "${RUBY_VERSION}"/' Gemfile
 RUN sed -i 's/^console/#console/' Procfile
 
+## set it to update feeds itself, rather than relying on CRON
 RUN echo "clock: clockwork clock.rb" >> Procfile
 
 RUN bundle install

--- a/run.sh
+++ b/run.sh
@@ -4,12 +4,12 @@
 ## Required variables
 #
 
-if [ -z $STRINGER_DATABASE_USERNAME ]; then
+if [ -z "$STRINGER_DATABASE_USERNAME" ]; then
   echo "STRINGER_DATABASE_USERNAME must be set"
   exit 1
 fi
 
-if [ -z $STRINGER_DATABASE_PASSWORD ]; then
+if [ -z "$STRINGER_DATABASE_PASSWORD" ]; then
   echo "STRINGER_DATABASE_PASSWORD must be set"
   exit 1
 fi
@@ -26,5 +26,9 @@ export SECRET_TOKEN=$(openssl rand -hex 20)
 
 cd /stringer
 
-rake db:migrate
-bundle exec foreman start
+## several versions of rake might get installed.  Let's use the
+## one we built with
+bundle exec rake db:migrate
+## using foreman 'straight', as the rubygems version will be the only
+## installed in the Dockerfile here enclosed
+foreman start


### PR DESCRIPTION
run.sh: change which argument uses bundle exec
Dockerfile: remove the hardcoded replacement ruby, and use RUBY_VERSION
which comes from our parent Ruby Dockerfile

(resolves #1 on languidnights' enviroment)
